### PR TITLE
refactor(logging): filehandler logs to /log/portal_client_log, removed filebeat from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,5 @@
-FROM ubuntu:16.04 as builder
-RUN apt update && apt install -y curl
-WORKDIR /
-RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-6.3.0-amd64.deb
-
 FROM python:3.6.6-slim
 ADD . /code
 WORKDIR /code
 RUN pip install -r requirements.txt
 WORKDIR /code/VirtualMachineService
-COPY --from=builder /filebeat-6.3.0-amd64.deb  .
-RUN dpkg -i filebeat-6.3.0-amd64.deb && rm -rf filebeat-6.3.0-amd64.deb

--- a/VirtualMachineService/VirtualMachineHandler.py
+++ b/VirtualMachineService/VirtualMachineHandler.py
@@ -82,7 +82,7 @@ class VirtualMachineHandler(Iface):
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.DEBUG)
         # create file handler which logs even debug messages
-        self.fh = logging.FileHandler("debug.log")
+        self.fh = logging.FileHandler("log/portal_client_debug.log")
         self.fh.setLevel(logging.DEBUG)
         # create console handler with a higher log level
         self.ch = logging.StreamHandler()

--- a/VirtualMachineService/log/.gitignore
+++ b/VirtualMachineService/log/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Dockerfile does not install Filebeat anymore and there is now a log folder in which logs get written.

Try to fulfill the following points before the Pull Request is merged:

- [ ] The PR is reviewed by one of the team members.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] If the new code is well commented
- [ ] Update the Changelog file 

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`
