### PR TITLE
feature(playbook): statuscode and logs from client to api

### DIFF
--- a/VirtualMachineService/VirtualMachineServer.py
+++ b/VirtualMachineService/VirtualMachineServer.py
@@ -2,12 +2,12 @@ import os
 import sys
 
 try:
-    from VirtualMachineService import Client, Processor
+    from VirtualMachineService.VirtualMachineService import Client, Processor
 except Exception:
     from VirtualMachineService import Client, Processor
 
 try:
-    from VirtualMachineHandler import VirtualMachineHandler
+    from  VirtualMachineService.VirtualMachineHandler import VirtualMachineHandler
 except Exception:
     from VirtualMachineHandler import VirtualMachineHandler
 

--- a/VirtualMachineService/VirtualMachineService-remote
+++ b/VirtualMachineService/VirtualMachineService-remote
@@ -39,6 +39,7 @@ if len(sys.argv) <= 1 or sys.argv[1] == '--help':
     print('   start_server(string flavor, string image, string public_key, string servername, string elixir_id, string diskspace, string volumename)')
     print('   start_server_with_custom_key(string flavor, string image, string servername, string elixir_id, string diskspace, string volumename)')
     print('  int create_and_deploy_playbook(string private_key, string play_source, string openstack_id)')
+    print('  PlaybookResult get_playbook_logs(string openstack_id)')
     print('  bool add_security_group_to_server(bool http, bool https, bool udp, string server_id)')
     print('  VM get_server(string openstack_id)')
     print('  bool stop_server(string openstack_id)')
@@ -221,6 +222,12 @@ elif cmd == 'create_and_deploy_playbook':
         print('create_and_deploy_playbook requires 3 args')
         sys.exit(1)
     pp.pprint(client.create_and_deploy_playbook(args[0], args[1], args[2],))
+
+elif cmd == 'get_playbook_logs':
+    if len(args) != 1:
+        print('get_playbook_logs requires 1 args')
+        sys.exit(1)
+    pp.pprint(client.get_playbook_logs(args[0],))
 
 elif cmd == 'add_security_group_to_server':
     if len(args) != 4:

--- a/VirtualMachineService/VirtualMachineService.py
+++ b/VirtualMachineService/VirtualMachineService.py
@@ -191,6 +191,16 @@ class Iface(object):
         """
         pass
 
+    def get_playbook_logs(self, openstack_id):
+        """
+        Get the logs from a playbook run
+
+        Parameters:
+         - openstack_id
+
+        """
+        pass
+
     def add_security_group_to_server(self, http, https, udp, server_id):
         """
         Adds a security group to a server
@@ -956,6 +966,40 @@ class Client(Iface):
             return result.success
         raise TApplicationException(TApplicationException.MISSING_RESULT, "create_and_deploy_playbook failed: unknown result")
 
+    def get_playbook_logs(self, openstack_id):
+        """
+        Get the logs from a playbook run
+
+        Parameters:
+         - openstack_id
+
+        """
+        self.send_get_playbook_logs(openstack_id)
+        return self.recv_get_playbook_logs()
+
+    def send_get_playbook_logs(self, openstack_id):
+        self._oprot.writeMessageBegin('get_playbook_logs', TMessageType.CALL, self._seqid)
+        args = get_playbook_logs_args()
+        args.openstack_id = openstack_id
+        args.write(self._oprot)
+        self._oprot.writeMessageEnd()
+        self._oprot.trans.flush()
+
+    def recv_get_playbook_logs(self):
+        iprot = self._iprot
+        (fname, mtype, rseqid) = iprot.readMessageBegin()
+        if mtype == TMessageType.EXCEPTION:
+            x = TApplicationException()
+            x.read(iprot)
+            iprot.readMessageEnd()
+            raise x
+        result = get_playbook_logs_result()
+        result.read(iprot)
+        iprot.readMessageEnd()
+        if result.success is not None:
+            return result.success
+        raise TApplicationException(TApplicationException.MISSING_RESULT, "get_playbook_logs failed: unknown result")
+
     def add_security_group_to_server(self, http, https, udp, server_id):
         """
         Adds a security group to a server
@@ -1520,6 +1564,7 @@ class Processor(Iface, TProcessor):
         self._processMap["start_server"] = Processor.process_start_server
         self._processMap["start_server_with_custom_key"] = Processor.process_start_server_with_custom_key
         self._processMap["create_and_deploy_playbook"] = Processor.process_create_and_deploy_playbook
+        self._processMap["get_playbook_logs"] = Processor.process_get_playbook_logs
         self._processMap["add_security_group_to_server"] = Processor.process_add_security_group_to_server
         self._processMap["get_server"] = Processor.process_get_server
         self._processMap["stop_server"] = Processor.process_stop_server
@@ -1951,6 +1996,29 @@ class Processor(Iface, TProcessor):
             msg_type = TMessageType.EXCEPTION
             result = TApplicationException(TApplicationException.INTERNAL_ERROR, 'Internal error')
         oprot.writeMessageBegin("create_and_deploy_playbook", msg_type, seqid)
+        result.write(oprot)
+        oprot.writeMessageEnd()
+        oprot.trans.flush()
+
+    def process_get_playbook_logs(self, seqid, iprot, oprot):
+        args = get_playbook_logs_args()
+        args.read(iprot)
+        iprot.readMessageEnd()
+        result = get_playbook_logs_result()
+        try:
+            result.success = self._handler.get_playbook_logs(args.openstack_id)
+            msg_type = TMessageType.REPLY
+        except TTransport.TTransportException:
+            raise
+        except TApplicationException as ex:
+            logging.exception('TApplication exception in handler')
+            msg_type = TMessageType.EXCEPTION
+            result = ex
+        except Exception:
+            logging.exception('Unexpected exception in handler')
+            msg_type = TMessageType.EXCEPTION
+            result = TApplicationException(TApplicationException.INTERNAL_ERROR, 'Internal error')
+        oprot.writeMessageBegin("get_playbook_logs", msg_type, seqid)
         result.write(oprot)
         oprot.writeMessageEnd()
         oprot.trans.flush()
@@ -4708,6 +4776,130 @@ class create_and_deploy_playbook_result(object):
 all_structs.append(create_and_deploy_playbook_result)
 create_and_deploy_playbook_result.thrift_spec = (
     (0, TType.I32, 'success', None, None, ),  # 0
+)
+
+
+class get_playbook_logs_args(object):
+    """
+    Attributes:
+     - openstack_id
+
+    """
+
+
+    def __init__(self, openstack_id=None,):
+        self.openstack_id = openstack_id
+
+    def read(self, iprot):
+        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+            return
+        iprot.readStructBegin()
+        while True:
+            (fname, ftype, fid) = iprot.readFieldBegin()
+            if ftype == TType.STOP:
+                break
+            if fid == 1:
+                if ftype == TType.STRING:
+                    self.openstack_id = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
+            else:
+                iprot.skip(ftype)
+            iprot.readFieldEnd()
+        iprot.readStructEnd()
+
+    def write(self, oprot):
+        if oprot._fast_encode is not None and self.thrift_spec is not None:
+            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+            return
+        oprot.writeStructBegin('get_playbook_logs_args')
+        if self.openstack_id is not None:
+            oprot.writeFieldBegin('openstack_id', TType.STRING, 1)
+            oprot.writeString(self.openstack_id.encode('utf-8') if sys.version_info[0] == 2 else self.openstack_id)
+            oprot.writeFieldEnd()
+        oprot.writeFieldStop()
+        oprot.writeStructEnd()
+
+    def validate(self):
+        return
+
+    def __repr__(self):
+        L = ['%s=%r' % (key, value)
+             for key, value in self.__dict__.items()]
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not (self == other)
+all_structs.append(get_playbook_logs_args)
+get_playbook_logs_args.thrift_spec = (
+    None,  # 0
+    (1, TType.STRING, 'openstack_id', 'UTF8', None, ),  # 1
+)
+
+
+class get_playbook_logs_result(object):
+    """
+    Attributes:
+     - success
+
+    """
+
+
+    def __init__(self, success=None,):
+        self.success = success
+
+    def read(self, iprot):
+        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+            return
+        iprot.readStructBegin()
+        while True:
+            (fname, ftype, fid) = iprot.readFieldBegin()
+            if ftype == TType.STOP:
+                break
+            if fid == 0:
+                if ftype == TType.STRUCT:
+                    self.success = PlaybookResult()
+                    self.success.read(iprot)
+                else:
+                    iprot.skip(ftype)
+            else:
+                iprot.skip(ftype)
+            iprot.readFieldEnd()
+        iprot.readStructEnd()
+
+    def write(self, oprot):
+        if oprot._fast_encode is not None and self.thrift_spec is not None:
+            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+            return
+        oprot.writeStructBegin('get_playbook_logs_result')
+        if self.success is not None:
+            oprot.writeFieldBegin('success', TType.STRUCT, 0)
+            self.success.write(oprot)
+            oprot.writeFieldEnd()
+        oprot.writeFieldStop()
+        oprot.writeStructEnd()
+
+    def validate(self):
+        return
+
+    def __repr__(self):
+        L = ['%s=%r' % (key, value)
+             for key, value in self.__dict__.items()]
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not (self == other)
+all_structs.append(get_playbook_logs_result)
+get_playbook_logs_result.thrift_spec = (
+    (0, TType.STRUCT, 'success', [PlaybookResult, None], None, ),  # 0
 )
 
 

--- a/VirtualMachineService/ancon/BiocondaPlaybook.py
+++ b/VirtualMachineService/ancon/BiocondaPlaybook.py
@@ -10,26 +10,14 @@ import subprocess
 class BiocondaPlaybook(object):
 
     def __init__(self, ip, port, play_source, osi_private_key, public_key):
-        self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(logging.DEBUG)
-        # create file handler which logs even debug messages
-        self.fh = logging.FileHandler("log/portal_client_ansible.log")
-        self.fh.setLevel(logging.DEBUG)
-        self.ch = logging.StreamHandler()
-        self.ch.setLevel(logging.DEBUG)
-        # create console handler with a higher log level
-        # create formatter and add it to the handlers
-        self.formatter = logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-        )
-        self.fh.setFormatter(self.formatter)
-        self.ch.setFormatter(self.formatter)
-        # add the handlers to the logger
-        self.logger.addHandler(self.fh)
-        self.logger.addHandler(self.ch)
+        self.status = -1
+        self.stdout = ''
+        self.stderr = ''
+        # directories and files
         self.ancon_dir = "/code/VirtualMachineService/ancon"
         self.playbooks_dir = self.ancon_dir + "/playbooks"
         self.directory = TemporaryDirectory(dir=self.ancon_dir)
+        #self.log_file = NamedTemporaryFile(mode='w+', delete=False, dir=self.directory.name)
         shutil.copy(self.playbooks_dir+"/bioconda.yml", self.directory.name)
         shutil.copy(self.playbooks_dir+"/variables.yml", self.directory.name)
         self.ip = ip
@@ -38,23 +26,52 @@ class BiocondaPlaybook(object):
         self.private_key.write(osi_private_key)
         self.private_key.close()
 
+        # logging
+        #self.logger = logging.getLogger(__name__)
+        #self.logger.setLevel(logging.DEBUG)
+        # create file handler which logs even debug messages
+        #self.fh = logging.FileHandler(self.log_file.name)
+        #self.fh.setLevel(logging.DEBUG)
+        # create formatter and add it to the handlers
+        #self.formatter = logging.Formatter(
+        #    "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        #)
+        #self.fh.setFormatter(self.formatter)
+        # add the handlers to the logger
+        #self.logger.addHandler(self.fh)
+
         # create inventory and add the to-be-installed tools to the variables.yml
         self.inventory = NamedTemporaryFile(mode="w+", dir=self.directory.name, delete=False)
         inventory_string = "[vm]\n" + self.ip + ":" + self.port + " ansible_user=ubuntu " \
                                                         "ansible_ssh_private_key_file=" + self.private_key.name
         self.inventory.write(inventory_string)
         self.inventory.close()
+
+        # load variables.yml and change some of its content
         yaml_exec = ruamel.yaml.YAML()
-        with open(self.directory.name + "/variables.yml", mode='r+') as variables:
+        with open(self.directory.name + "/variables.yml", mode='r') as variables:
             data = yaml_exec.load(variables)
             data["tools"]["string_line"] = play_source.strip('\"')
             data["tools"]["public_key"] = public_key.strip('\"')
+            data["tools"]["timeout_length"] = str(len(play_source.split()) * 5) + "m"
+        with open(self.directory.name + "/variables.yml", mode='w') as variables:
             yaml_exec.dump(data, variables)
 
     def run_it(self):
-        command_string = "/usr/local/bin/ansible-playbook -vvv -i " + self.inventory.name + " " + self.directory.name + "/bioconda.yml"
+        command_string = "/usr/local/bin/ansible-playbook -v -i {0} {1}/bioconda.yml"\
+            .format(self.inventory.name, self.directory.name)
         command_string = shlex.split(command_string)
         process = subprocess.run(command_string, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
-        self.logger.log(level=20, msg=process.stdout)
-        self.logger.log(level=50, msg=process.stderr)
+        # self.logger.log(level=20, msg=process.stdout)
+        self.stdout = process.stdout
+        if len(process.stderr) > 0:
+            self.stderr = process.stderr
+            # self.logger.log(level=50, msg=process.stderr)
+        self.status = process.returncode
+        return process.returncode, process.stdout, process.stderr
+
+    def get_logs(self):
+        return self.status, self.stdout, self.stderr
+
+    def cleanup(self):
         self.directory.cleanup()

--- a/VirtualMachineService/ancon/playbooks/bioconda.yml
+++ b/VirtualMachineService/ancon/playbooks/bioconda.yml
@@ -1,4 +1,4 @@
-- name: Install miniconda3 and a Test-Package
+- name: Install miniconda3 and the chosen packages
   hosts: all
   connection: paramiko_ssh
   gather_facts: yes
@@ -12,29 +12,30 @@
         url: "{{ folders.conda_installer_url }}"
         dest: "{{ folders.install_script }}"
         mode: 0755
+        timeout: 180
 
     - name: Install miniconda
-      shell: "{{ folders.install_script }} -b"
+      shell: "timeout 3m {{ folders.install_script }} -b"
       args:
         executable: /bin/bash
         creates: "{{ folders.conda_dir }}"
 
-    - name: Add Channels
-      shell: "source {{ folders.conda_dir }}/bin/activate && conda config --add channels default && conda config --add channels bioconda && conda config --add channels conda-forge"
+    - name: Add channels
+      shell: "timeout 2m bash -c 'source {{ folders.conda_dir }}/bin/activate && conda config --add channels default && conda config --add channels bioconda && conda config --add channels conda-forge'"
       args:
         executable: /bin/bash
 
-    - name: Create Environment
-      shell: "source {{ folders.conda_dir }}/bin/activate && conda create --yes -n {{ tools.env }}"
+    - name: Create environment
+      shell: "timeout 2m bash -c 'source {{ folders.conda_dir }}/bin/activate && conda create --yes -n {{ tools.env }}'"
       args:
         executable: /bin/bash
 
-    - name: Install Test-Package
-      shell: "source {{ folders.conda_dir }}/bin/activate && conda activate {{ tools.env }} && conda install --yes {{ tools.string_line }}"
+    - name: Install chosen packages
+      shell: "timeout {{ tools.timeout_length }} bash -c 'source {{ folders.conda_dir }}/bin/activate && conda activate {{ tools.env }} && conda install --yes {{ tools.string_line }}'"
       args:
         executable: /bin/bash
 
-    - name: Set Public Key and remove old Public Key
+    - name: Set user public Key and remove created public Key
       authorized_key:
         user: ubuntu
         key: '{{ tools.public_key }}'

--- a/VirtualMachineService/ancon/playbooks/variables.yml
+++ b/VirtualMachineService/ancon/playbooks/variables.yml
@@ -2,6 +2,7 @@ tools:
   string_line: ""
   env: "denbi"
   public_key: ""
+  timeout_length: "5m"
 
 folders:
   install_script: "/home/{{ ansible_user_id }}/install_miniconda3.sh"

--- a/VirtualMachineService/ttypes.py
+++ b/VirtualMachineService/ttypes.py
@@ -547,6 +547,93 @@ class VM(object):
         return not (self == other)
 
 
+class PlaybookResult(object):
+    """
+    This Struct defines the result of a playbook run.
+
+    Attributes:
+     - status: The exit status code of the run
+     - stdout: The standard logs of the run
+     - stderr: The error logs of the run
+
+    """
+
+
+    def __init__(self, status=None, stdout=None, stderr=None,):
+        self.status = status
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def read(self, iprot):
+        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+            return
+        iprot.readStructBegin()
+        while True:
+            (fname, ftype, fid) = iprot.readFieldBegin()
+            if ftype == TType.STOP:
+                break
+            if fid == 1:
+                if ftype == TType.I32:
+                    self.status = iprot.readI32()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 2:
+                if ftype == TType.STRING:
+                    self.stdout = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 3:
+                if ftype == TType.STRING:
+                    self.stderr = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
+            else:
+                iprot.skip(ftype)
+            iprot.readFieldEnd()
+        iprot.readStructEnd()
+
+    def write(self, oprot):
+        if oprot._fast_encode is not None and self.thrift_spec is not None:
+            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+            return
+        oprot.writeStructBegin('PlaybookResult')
+        if self.status is not None:
+            oprot.writeFieldBegin('status', TType.I32, 1)
+            oprot.writeI32(self.status)
+            oprot.writeFieldEnd()
+        if self.stdout is not None:
+            oprot.writeFieldBegin('stdout', TType.STRING, 2)
+            oprot.writeString(self.stdout.encode('utf-8') if sys.version_info[0] == 2 else self.stdout)
+            oprot.writeFieldEnd()
+        if self.stderr is not None:
+            oprot.writeFieldBegin('stderr', TType.STRING, 3)
+            oprot.writeString(self.stderr.encode('utf-8') if sys.version_info[0] == 2 else self.stderr)
+            oprot.writeFieldEnd()
+        oprot.writeFieldStop()
+        oprot.writeStructEnd()
+
+    def validate(self):
+        if self.status is None:
+            raise TProtocolException(message='Required field status is unset!')
+        if self.stdout is None:
+            raise TProtocolException(message='Required field stdout is unset!')
+        if self.stderr is None:
+            raise TProtocolException(message='Required field stderr is unset!')
+        return
+
+    def __repr__(self):
+        L = ['%s=%r' % (key, value)
+             for key, value in self.__dict__.items()]
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not (self == other)
+
+
 class otherException(TException):
     """
     Attributes:
@@ -1067,6 +1154,13 @@ VM.thrift_spec = (
     (11, TType.STRING, 'fixed_ip', 'UTF8', None, ),  # 11
     (12, TType.I32, 'diskspace', None, None, ),  # 12
     (13, TType.STRING, 'volume_id', 'UTF8', None, ),  # 13
+)
+all_structs.append(PlaybookResult)
+PlaybookResult.thrift_spec = (
+    None,  # 0
+    (1, TType.I32, 'status', None, None, ),  # 1
+    (2, TType.STRING, 'stdout', 'UTF8', None, ),  # 2
+    (3, TType.STRING, 'stderr', 'UTF8', None, ),  # 3
 )
 all_structs.append(otherException)
 otherException.thrift_spec = (

--- a/portal_client.thrift
+++ b/portal_client.thrift
@@ -111,12 +111,22 @@ struct VM {
 
     /** Id of additional volume */
 	13:optional string volume_id
-
-
-
-
-	
 }
+
+/**
+ * This Struct defines the result of a playbook run.
+ */
+struct PlaybookResult {
+    /**The exit status code of the run*/
+    1: required int status
+    /**The standard logs of the run*/
+    2: required string stdout
+    /**The error logs of the run*/
+    3: required string stderr
+}
+
+
+
 
 
 exception otherException {
@@ -332,7 +342,12 @@ service VirtualMachineService {
     1:string private_key,
     2:string play_source,
     3:string openstack_id
-   )
+    )
+
+    /** Get the logs from a playbook run*/
+    PlaybookResult get_playbook_logs(
+    1:string openstack_id
+    )
 
     /**
     * Adds a security group to a server


### PR DESCRIPTION
@DavidWein94 
The logs do not get saved anymore by the client. They are temporarily saved in the playbook object and get deleted after sending them to the api. Timeout increased for some tasks. VM deleted if failed.
To test failing the playbook, add 
- name: Let it Fail
      fail:
        msg: It Failed
as a task somewhere in cloud-portal-client/VirtualMachineService/ancon/playbooks/bioconda.yml
Also to test timeout, e.g. change in ancon/BiocondaPlaybook.py in line 56 the timeout to 3s.

Needs https://github.com/deNBI/cloud-api/pull/803 and https://github.com/deNBI/cloud-portal-webapp/pull/592

Try to fulfill the following points before the Pull Request is merged:

- [ ] The PR is reviewed by one of the team members.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] If the new code is well commented
- [ ] Update the Changelog file 

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`
