### PR TITLE
fix(playbook): user key task always run, fix miniconda3 version, ansible==2.7.14

### DIFF
--- a/VirtualMachineService/ancon/playbooks/bioconda_vars_file.yml
+++ b/VirtualMachineService/ancon/playbooks/bioconda_vars_file.yml
@@ -6,4 +6,4 @@ bioconda_tools:
 bioconda_folders:
   install_script: "/home/{{ ansible_user_id }}/install_miniconda3.sh"
   conda_dir: "/home/{{ ansible_user_id }}/miniconda3"
-  conda_installer_url: "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+  conda_installer_url: "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12-Linux-x86_64.sh"

--- a/VirtualMachineService/ancon/playbooks/bioconda_vars_file.yml
+++ b/VirtualMachineService/ancon/playbooks/bioconda_vars_file.yml
@@ -6,4 +6,4 @@ bioconda_tools:
 bioconda_folders:
   install_script: "/home/{{ ansible_user_id }}/install_miniconda3.sh"
   conda_dir: "/home/{{ ansible_user_id }}/miniconda3"
-  conda_installer_url: "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12-Linux-x86_64.sh"
+  conda_installer_url: "https://repo.anaconda.com/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh"

--- a/VirtualMachineService/ancon/playbooks/generic_playbook.yml
+++ b/VirtualMachineService/ancon/playbooks/generic_playbook.yml
@@ -4,3 +4,6 @@
   gather_facts: yes
   vars_files:
   tasks:
+    - name: Setting up your virtual machine
+      block:
+      always:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ openstacksdk ==0.27.0
 deprecated == 1.2.4
 Click==7.0
 flake8==3.7.7
-ansible==2.8.0
+ansible==2.7.14
 ruamel.yaml<0.16.00
 paramiko==2.6.0
 pyvim==2.0.24


### PR DESCRIPTION
@vktrrdk 
The task for getting the public key of the user on the vm will now always be run, whether the playbook script fails or not.

Test with: 
https://github.com/deNBI/cloud-api/pull/903
https://github.com/deNBI/cloud-portal-webapp/pull/809

Try to fulfill the following points before the Pull Request is merged:

- [ ] The PR is reviewed by one of the team members.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] If the new code is well commented
- [ ] Update the Changelog file 

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`
