### PR TITLE
Feat/filebeat location

### DIFF
--- a/.env.in
+++ b/.env.in
@@ -5,7 +5,8 @@ FORC_API_KEY=
 ELASTIC_USER=
 ELASTIC_PASSWORD=
 FILEBEAT_TAG=7.1.0
-HOST=cloud.denbi.de
+HOST=portal-dev.denbi.de
+REGION=Giessen-Staging
 
 OS_AUTH_URL=
 OS_PROJECT_ID=

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -17,6 +17,7 @@ output.elasticsearch:
 filebeat.inputs:
   - type: log
     enabled: true
+    exclude_files: ['\.swp$']
     paths:
       - /usr/share/filebeat/log/client/*.log
     multiline:

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -1,3 +1,7 @@
+fields_under_root: true
+fields:
+  region: '${REGION}'
+
 output.elasticsearch:
     hosts:
       - 'https://${HOST}:443'

--- a/plays/setup_client.yml
+++ b/plays/setup_client.yml
@@ -23,12 +23,12 @@
       tags: always
 
     - name: Setup filebeat data directory
-        file:
+      file:
           path: "{{ client.FILEBEAT_PATH }}"
           state: directory
           owner: ubuntu
           group: ubuntu
-        tags: always
+      tags: always
 
     # Copy configs
     - name: Copy client config file from config folder


### PR DESCRIPTION
@dweinholz
New field for all filebeat logs: region, so we know which filebeat sends the logs.
Excludes .swp files.
REGION= needs to be set in your .env when setting up client with ansible!

Try to fulfill the following points before the Pull Request is merged:

- [x] The PR is reviewed by one of the team members.
- [x] If the PR is merged in the master then a release should be be made.
- [x] If the new code is well commented
- [ ] Update the Changelog file 

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`
