### PR TITLE
fix guacamole playbook

### DIFF
--- a/VirtualMachineService/ancon/playbooks/guacamole.yml
+++ b/VirtualMachineService/ancon/playbooks/guacamole.yml
@@ -1,3 +1,26 @@
+- name: Disable periodic updates
+  block:
+    - name: Disable unattended upgrades
+      lineinfile:
+        path: /etc/apt/apt.conf.d/10periodic
+        regexp: "^APT::Periodic::Unattended-Upgrade"
+        line: 'APT::Periodic::Unattended-Upgrade "0";'
+        create: yes
+    - name: Stop apt-daily.* systemd services
+      service:
+        name: "{{ item }}"
+        state: stopped
+      with_items:
+        - unattended-upgrades
+        - apt-daily
+        - apt-daily.timer
+        - apt-daily-upgrade
+        - apt-daily-upgrade.timer
+    - name: Uninstall unattended upgrades
+      apt:
+        name: unattended-upgrades
+        state: absent
+
 - name: Wait for automatic system updates 1
   shell: while sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1; do sleep 1; done;
 
@@ -41,3 +64,26 @@
   systemd:
     daemon_reload: yes
   when: guacamole_vars.create_only_backend == "true"
+
+- name: Enable periodic updates
+  block:
+    - name: Disable unattended upgrades
+      lineinfile:
+        path: /etc/apt/apt.conf.d/10periodic
+        regexp: "^APT::Periodic::Unattended-Upgrade"
+        line: 'APT::Periodic::Unattended-Upgrade "0";'
+        create: yes
+    - name: Stop apt-daily.* systemd services
+      service:
+        name: "{{ item }}"
+        state: started
+      with_items:
+        - unattended-upgrades
+        - apt-daily
+        - apt-daily.timer
+        - apt-daily-upgrade
+        - apt-daily-upgrade.timer
+    - name: Install unattended upgrades
+      apt:
+        name: unattended-upgrades
+        state: build-dep


### PR DESCRIPTION
@dweinholz 

Fixes the lock bug with apt by removing unattended packages and stops systemd services at the start. At the end the services are restarted and unattended packages installed

Try to fulfill the following points before the Pull Request is merged:

- [ ] The PR is reviewed by one of the team members.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] If the new code is well commented
- [ ] Update the Changelog file 

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`
