### PR TITLE
feat(Display Version of Resenv): add support for display versioning

### DIFF
--- a/VirtualMachineService/VirtualMachineHandler.py
+++ b/VirtualMachineService/VirtualMachineHandler.py
@@ -89,6 +89,7 @@ SECURITYGROUP_SSH = "securitygroup_ssh"
 DIRECTION = "direction"
 PROTOCOL = "protocol"
 TEMPLATE_NAME = "template_name"
+INFORMATION_FOR_DISPLAY = "information_for_display"
 
 
 class VirtualMachineHandler(Iface):
@@ -2715,6 +2716,7 @@ class VirtualMachineHandler(Iface):
                     template_metadata[SECURITYGROUP_SSH],
                     template_metadata[DIRECTION],
                     template_metadata[PROTOCOL],
+                    template_metadata[INFORMATION_FOR_DISPLAY],
                 )
                 if metadata.name not in list(self.loaded_resenv_metadata.keys()):
                     self.loaded_resenv_metadata[metadata.name] = metadata
@@ -2761,6 +2763,7 @@ class ResenvMetadata:
         security_group_ssh,
         direction,
         protocol,
+        information_for_display,
     ):
         self.name = name
         self.port = port
@@ -2769,3 +2772,4 @@ class ResenvMetadata:
         self.security_group_ssh = security_group_ssh
         self.direction = direction
         self.protocol = protocol
+        self.information_for_display = information_for_display


### PR DESCRIPTION
@eKatchko 
Now the version of the tool is displayed in the webapp (start new vm select resenv)
Use corresponding branches in cloud-api and cloud-portal-webapp

**Use the following setting for the env file:** 
GITHUB_PLAYBOOKS_REPO=https://api.github.com/repos/deNBI/resenvs/contents?ref=feat/displayversion


Try to fulfill the following points before the Pull Request is merged:

- [ ] The PR is reviewed by one of the team members.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] If the new code is readable, if not it should be well commented
- [ ] Update the Changelog file 

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`
