### PR TITLE
refactor(Bibigrd): refactored bibigrd config

### DIFF
--- a/VirtualMachineService/VirtualMachineHandler.py
+++ b/VirtualMachineService/VirtualMachineHandler.py
@@ -199,7 +199,7 @@ class VirtualMachineHandler(Iface):
                     self.BIBIGIRD_EP = f"https://{self.BIBIGRID_HOST}:{self.BIBIGRID_PORT}"
                 else:
                     self.BIBIGRID_URL = f"http://{self.BIBIGRID_HOST}:{self.BIBIGRID_PORT}/bibigrid"
-                    self.BIBIGIRD_EP = f"https://{self.BIBIGRID_HOST}:{self.BIBIGRID_PORT}"
+                    self.BIBIGIRD_EP = f"http://{self.BIBIGRID_HOST}:{self.BIBIGRID_PORT}"
 
                 LOG.info(msg="Bibigrd url loaded: {0}".format(self.BIBIGRID_URL))
             except Exception as e:

--- a/VirtualMachineService/VirtualMachineHandler.py
+++ b/VirtualMachineService/VirtualMachineHandler.py
@@ -2053,7 +2053,6 @@ class VirtualMachineHandler(Iface):
 
             else:
 
-                LOG.info("Bibigrid Port is not open")
                 LOG.exception("Bibigrid is offline")
                 return False
 

--- a/VirtualMachineService/config/config.yml
+++ b/VirtualMachineService/config/config.yml
@@ -39,7 +39,7 @@ bibigrid:
   # Url for Bibigrid API
     port: 8080
     host: bibigrid
-    bibigrid_url: http://{host}:{port}/bibigrid/
+    https: False
     sub_network: portalexternalsubnetwork
     bibigrid_modes:
       -   slurm


### PR DESCRIPTION
@eKatchko 

Refactored Bibigrid config entry - removed confusing bibigrid_url and only use port host and https vars

Also bibigrid_available doesnt check anymore is the port is open it now requests the /server/health ep


Try to fulfill the following points before the Pull Request is merged:

- [ ] The PR is reviewed by one of the team members.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] If the new code is readable, if not it should be well commented

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`
