### PR TITLE
fix(pem-script): argument will also be directory name

### DIFF
--- a/scripts/generate_new_test_pems.sh
+++ b/scripts/generate_new_test_pems.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/expect
 echo Creating new dir "new_pem"
-mkdir new_pem
-cd new_pem
+mkdir $1
+cd $1
 openssl req -new -x509 -nodes -days 3000 -out server.crt -keyout server.key -subj "/C=DE/ST=./L=./O=./CN=$1"  
 
 openssl x509 -in server.crt -text > CA.pem


### PR DESCRIPTION
@dweinholz 
Script for new pems will generate argument as directory instead new_pem

Try to fulfill the following points before the Pull Request is merged:

- [ ] The PR is reviewed by one of the team members.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] If the new code is readable, if not it should be well commented

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`
