### PR TITLE
fix(forc): split forc url without specific port

### DIFF
--- a/VirtualMachineService/VirtualMachineHandler.py
+++ b/VirtualMachineService/VirtualMachineHandler.py
@@ -1300,8 +1300,8 @@ class VirtualMachineHandler(Iface):
         if self.RE_BACKEND_URL is None:
             return ""
         else:
-            url = self.RE_BACKEND_URL.split(":5000", 1)[0]
-            return "{0}/".format(url)
+            url = self.RE_BACKEND_URL.split(":")
+            return f"https:{url[1]}/"
 
     def cross_check_forc_image(self, tags):
         get_url = "{0}templates/".format(self.RE_BACKEND_URL)


### PR DESCRIPTION
@dweinholz 
Different way to split forc url without specifying port

Try to fulfill the following points before the Pull Request is merged:

- [ ] The PR is reviewed by one of the team members.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] If the new code is readable, if not it should be well commented

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`
