### PR TITLE
feat(cli): updated playbook to automatically install python3.8

### DIFF
--- a/plays/setup_basics.yml
+++ b/plays/setup_basics.yml
@@ -37,6 +37,18 @@
       become: no
       tags: always
 
+    - name: Import deadsnake PPA for python3.8
+      ansible.builtin.apt_repository:
+        repo: ppa:deadsnakes/ppa
+        update_cache: yes
+      tags: always
+
+    - name: Install python3.8
+      apt:
+        state: latest
+        name: python=3.8
+      tags: always
+
     - name: Install python3-pip
       apt:
         state: latest


### PR DESCRIPTION
@dweinholz 
The playbook of cloud-portal-client is also updated to auto-install python3.8 using PPA.

Try to fulfill the following points before the Pull Request is merged:

- [ ] The PR is reviewed by one of the team members.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] If the new code is readable, if not it should be well commented

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`
