### PR TITLE
fix(cli): moved apt-update into pre_tasks to prevent error

### DIFF
--- a/plays/setup_basics.yml
+++ b/plays/setup_basics.yml
@@ -11,15 +11,13 @@
 
 
   pre_tasks:
-    - name: Verify Ansible version.
+    - name: Verify Ansible version
       assert:
         that: "ansible_version.full is version_compare('2.7', '>=')"
         msg: >
           "You must update Ansible to at least 2.7"L
       tags: always
 
-
-  tasks:
     - name: Update cache
       apt:
         upgrade: yes
@@ -27,6 +25,8 @@
         cache_valid_time: 86400 #One day
       tags: always
 
+
+  tasks:
     - name: Checkout cloud-portal-client repository
       git:
         repo: "git@github.com:deNBI/cloud-portal-client.git"


### PR DESCRIPTION
@dweinholz 
Moved "Update cache" from tasks to pre_tasks and removed period from previous task name.

Try to fulfill the following points before the Pull Request is merged:

- [ ] The PR is reviewed by one of the team members.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] If the new code is readable, if not it should be well commented

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`
