### PR TITLE
fix(Bibigrid):clean keys via cronjob

### DIFF
--- a/docker-compose.bibigrid.yml
+++ b/docker-compose.bibigrid.yml
@@ -26,6 +26,8 @@ services:
   bibigrid:
     container_name: bibigrid
     image: bibiserv/bibigrid:bibigrid-rest-2.3
+    volumes:
+      - ./scripts/bibigrid/clear_keys_cron:/etc/crontabs/root
     env_file:
       - .env
     environment:

--- a/docker-compose.dev.bibigrid.yml
+++ b/docker-compose.dev.bibigrid.yml
@@ -29,6 +29,8 @@ services:
     image: bibiserv/bibigrid:bibigrid-rest-2.3
     env_file:
       - .env
+    volumes:
+      - ./scripts/bibigrid/clear_keys_cron:/etc/crontabs/root
     environment:
       - server.enableHttps=false
       - server.enableHttp=true

--- a/scripts/bibigrid/clear_keys_cron
+++ b/scripts/bibigrid/clear_keys_cron
@@ -1,0 +1,6 @@
+0 1 * * * bash  rm -rf /root/.bibigrid/keys/* >> /var/log/cron.log 2>&1
+*/15    *       *       *       *       run-parts /etc/periodic/15min
+0       *       *       *       *       run-parts /etc/periodic/hourly
+0       2       *       *       *       run-parts /etc/periodic/daily
+0       3       *       *       6       run-parts /etc/periodic/weekly
+0       5       1       *       *       run-parts /etc/periodic/monthly


### PR DESCRIPTION
@eKatchko 

Cornjob to delete keys inside bibigrid container / currently they are stored as long as the container is alive

Try to fulfill the following points before the Pull Request is merged:

- [ ] The PR is reviewed by one of the team members.
- [ ] If a linting PR exists, it must be merged before this PR is allowed to be merged.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] If the new code is readable, if not it should be well commented

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file 
  in the cloud-portal repo should also be updated. 
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`
